### PR TITLE
Fix a GC bug: was depending on undefined evaluation order.

### DIFF
--- a/lst4/source/globs.h
+++ b/lst4/source/globs.h
@@ -8,7 +8,7 @@
 #include <stdio.h>
 
 extern int fileIn(FILE * fp), fileOut(FILE * fp);
-extern void sysError(char *, unsigned int), flushCache(void);
+extern void sysError(char *, unsigned long), flushCache(void);
 extern struct object *primitive(int, struct object *, int *);
 
 #endif /* GLOBS_H */

--- a/lst4/source/interp.c
+++ b/lst4/source/interp.c
@@ -439,9 +439,9 @@ execute(struct object *aProcess, int ticks)
 	    high = VAL;
 	    bytePointer += VALSIZE;
 	    rootStack[rootTop++] = context;
-	    op = rootStack[rootTop++] = 
-	     gcalloc(x = integerValue(method->data[stackSizeInMethod]));
+	    op = gcalloc(x = integerValue(method->data[stackSizeInMethod]));
 	    op->class = ArrayClass;
+	    rootStack[rootTop++] = op;
 	    bzero(bytePtr(op), x * BytesPerWord);
 	    returnedValue = gcalloc(blockSize);
 	    returnedValue->class = BlockClass;
@@ -576,9 +576,9 @@ checkCache:
 	    rootStack[rootTop++] = method;
 	    rootStack[rootTop++] = context;
 	    low = integerValue(method->data[temporarySizeInMethod]);
-	    op = rootStack[rootTop++] = 
-	     gcalloc(x = integerValue(method->data[stackSizeInMethod]));
+	    op = gcalloc(x = integerValue(method->data[stackSizeInMethod]));
 	    op->class = ArrayClass;
+	    rootStack[rootTop++] = op;
 	    bzero(bytePtr(op), x * BytesPerWord);
 	    if (low > 0) {
 		    int i;

--- a/lst4/source/main.c
+++ b/lst4/source/main.c
@@ -37,9 +37,9 @@ unsigned int debugging = 0, cacheHit = 0, cacheMiss = 0, gccount = 0;
 static char *tmpdir = DefaultTmpdir;
 
 void
-sysError(char * a, unsigned int b)
+sysError(char * a, unsigned long b)
 {
-	fprintf(stderr,"unrecoverable system error: %s 0x%x\n", a, b);
+	fprintf(stderr,"unrecoverable system error: %s 0x%lx\n", a, b);
 	exit(1);
 }
 


### PR DESCRIPTION
I went hunting for whatever bugs make lst4 fail with a GC invariant error on some platforms, like Cygwin. To do this, I made it run the GC on every opportunity, and that made it quick crashed during startup with the standard image, even on 64-bit Linux where it normally works. This patch makes it run again without crashing. (I've only tested it on the same 64-bit Linux so far. The GC-all-the-time-for-debugging change is not in this patch.)

There are a couple of lines in the bytecode interpreter like

    rootStack[rootTop++] = gcalloc(foo)

But the C standard doesn't determine whether the increment happens before or after the call to gcalloc. (At least, that's how I remember it.) If the increment happens first, then the GC will think there's an extra element on top of the root stack, with whatever was in there before. I think the crash was from when that garbage element points into the wrong semispace.

Unrelated: widen the type of numeric argument to sysError, because it was getting truncated when cast from a pointer. I ran into this while debugging the above.